### PR TITLE
Fix switch template labels

### DIFF
--- a/wiretide/templates/switch.html
+++ b/wiretide/templates/switch.html
@@ -2,11 +2,11 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>Router Config - {{ device.hostname }}</title>
+  <title>Switch Config - {{ device.hostname }}</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="p-6 bg-gray-100 font-sans">
-  <h1 class="text-2xl font-bold mb-4">Router: {{ device.hostname }}</h1>
+  <h1 class="text-2xl font-bold mb-4">Switch: {{ device.hostname }}</h1>
 
   <div class="bg-white p-4 rounded shadow space-y-2">
     <p><strong>MAC:</strong> {{ device.mac }}</p>


### PR DESCRIPTION
## Summary
- change heading and title text in switch template

## Testing
- `grep -n "Router" wiretide/templates/switch.html`

------
https://chatgpt.com/codex/tasks/task_e_6885fd293ed8832dbaab3e47871f62c9