### PR TITLE
Potential fix for code scanning alert no. 1: Regular expression injection

### DIFF
--- a/wiretide/api/logs.py
+++ b/wiretide/api/logs.py
@@ -28,7 +28,7 @@ async def get_logs(level: str = "ALL"):
 
     # Filter by level if needed
     if level != "ALL":
-        regex = re.compile(rf"\b{level}\b")
+        regex = re.compile(rf"\b{re.escape(level)}\b")
         lines = [line for line in lines if regex.search(line)]
     return {"lines": lines}
 


### PR DESCRIPTION
Potential fix for [https://github.com/simonsays-techtalk/wiretide-controller/security/code-scanning/1](https://github.com/simonsays-techtalk/wiretide-controller/security/code-scanning/1)

To fix the problem, we should sanitize the `level` variable before embedding it in the regular expression. The best way to do this in Python is to use `re.escape(level)`, which escapes all special regex characters, ensuring that the input is treated as a literal string. This change should be made on line 31, where the regex is constructed. No other changes are necessary, as the rest of the code is unaffected. The `re` module is already imported, so no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
